### PR TITLE
Add a min-height 200 for config

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
             color: silver;
             border-color: darkgray;
         }
+        .hammerspoon-config {
+            min-height: 200px;
+        }
     </style>
 </head>
 <body>
@@ -26,7 +29,7 @@
         </div>    
     </div>
 
-<pre class="language-lua">
+<pre class="language-lua hammerspoon-config">
 // 🔨🥄 Example hammerspoon config
 
 // Paste your keystrokes array defn here.


### PR DESCRIPTION
Quick `min-height: 200px;` on the hammerspoon config to ensure it's always visible/readily copyable at the end of the page when the keystrokes get too long

Before:
<img width="818" alt="image" src="https://github.com/dps/typey/assets/68715117/fa243c63-5ded-4ab6-84f9-034ba1e325b7">

After:
<img width="816" alt="image" src="https://github.com/dps/typey/assets/68715117/2ad061f6-0c81-4a31-83ab-8b1cb573845b">